### PR TITLE
Find ud af hvad den kan

### DIFF
--- a/job_scraper_and_cleanup.py
+++ b/job_scraper_and_cleanup.py
@@ -371,16 +371,11 @@ class JobScraperAndCleanup:
             return False
         
         try:
-            # Use RLS-enabled client methods (handles duplicates and last_seen updates)
+            # Use RLS-enabled client methods (handles duplicates, restoration, and last_seen updates)
             success = self.supabase.insert_jobs(self.jobs)
             
             if success:
-                logger.info(f"✅ Successfully saved {len(self.jobs)} jobs with RLS compliance")
-                
-                # Restore any previously deleted jobs
-                job_ids = [job['job_id'] for job in self.jobs]
-                self.supabase.restore_deleted_jobs(job_ids)
-                
+                logger.info(f"✅ Successfully processed {len(self.jobs)} jobs with RLS compliance")
                 return True
             else:
                 logger.error("Failed to save jobs with RLS compliance")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correctly reactivate soft-deleted jobs when found again by the scraper.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the job duplicate detection logic incorrectly treated soft-deleted jobs as active, preventing their re-activation. This PR refines the `insert_jobs` method to distinguish between new, active, and soft-deleted jobs, ensuring that soft-deleted entries are properly restored and their `last_seen` timestamp is updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-d69a5e66-3a1c-418b-9b9f-162bde2f6424">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d69a5e66-3a1c-418b-9b9f-162bde2f6424">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>